### PR TITLE
Utility method to retrieve current version from git tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.2.3
 
-
+- Added hxmake.utils.GitTools#getCurrentTagVersion for retrieving current version from git tag
 
 # v0.2.2
 

--- a/src/hxmake/utils/GitTools.hx
+++ b/src/hxmake/utils/GitTools.hx
@@ -1,0 +1,26 @@
+package hxmake.utils;
+import hxmake.cli.CL;
+class GitTools {
+    /**
+        Return recent tag name with commit hash in format:
+        {tag name}-{commits count past recent tag}-{eight chars hash of last commit}
+
+        E.g.:
+            - If current position in tree referes to tag commit: 2.1.0
+            - If current position in tree referes to two commits past tag: 2.1.0-2-g2414721
+
+        @param dropSuffix   Drop last commit hash and commits count past tag
+    **/
+
+    public static function getCurrentTagVersion(dropSuffix:Bool = false):String {
+        var args = ["describe", "--tags"];
+        if (dropSuffix) {
+            args[args.length] = "--abbrev=0";
+        }
+        var result = CL.execute("git", args);
+        if (result.exitCode != 0) {
+            throw 'Can\'t get library version from git.\nExit code: ${result.exitCode}\n${result.stderr}';
+        }
+        return StringTools.trim(result.stdout);
+    }
+}


### PR DESCRIPTION
Added hxmake.utils.GitTools#getCurrentTagVersion for retrieving current version from git tag