### PR TITLE
v0.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
   - osx
 
 haxe:
-  - "3.4.4"
+  - "3.4.7"
   - development
 
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added hxmake.utils.GitTools#getCurrentTagVersion for retrieving current version from git tag
 - Fix `--override-test-target` property for TestTask
+- Update CI scripts
+- Fix Haxe 4.0 compatibility
 
 # v0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.2.3
 
-
+- Added hxmake.utils.GitTools#getCurrentTagVersion for retrieving current version from git tag
 
 # v0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.3
+
+
+
 # v0.2.2
 
 - Fix #33. Launching of Intellij IDEA project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.2.3
 
 - Added hxmake.utils.GitTools#getCurrentTagVersion for retrieving current version from git tag
+- Fix `--override-test-target` property for TestTask
 
 # v0.2.2
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Build tools for Haxe
 [![Build Status](https://ci.appveyor.com/api/projects/status/lxmpp7d9pfoyd7dq/branch/develop?svg=true)](https://ci.appveyor.com/project/eliasku/hxmake)
 
 [![Lang](https://img.shields.io/badge/language-haxe-orange.svg)](http://haxe.org)
-[![Version](https://img.shields.io/badge/version-v0.2.2-green.svg)](https://github.com/eliasku/hxmake)
+[![Version](https://img.shields.io/badge/version-v0.2.3-green.svg)](https://github.com/eliasku/hxmake)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
 ### Installation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ branches:
     - develop
 
 install:
+  - ps: Set-Service wuauserv -StartupType Manual
   - cinst neko --version 2.2.0 -y
   - cinst haxe --version %HAXE_VERSION% --ignore-dependencies -y
   - RefreshEnv

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   global:
     HAXELIB_ROOT: C:\projects\haxelib
   matrix:
-    - HAXE_VERSION: "3.4.4"
+    - HAXE_VERSION: "3.4.7"
 
 build: off
 
@@ -13,7 +13,8 @@ branches:
     - develop
 
 install:
-  - cinst haxe -version %HAXE_VERSION% -y
+  - cinst neko --version 2.2.0 -y
+  - cinst haxe --version %HAXE_VERSION% --ignore-dependencies -y
   - RefreshEnv
   - mkdir "%HAXELIB_ROOT%"
   - haxelib setup "%HAXELIB_ROOT%"

--- a/haxelib.json
+++ b/haxelib.json
@@ -18,6 +18,6 @@
 		"eliasku"
 	],
 	"releasenote": "see changelog",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"url": "https://github.com/eliasku/hxmake"
 }

--- a/make/HxMake.hx
+++ b/make/HxMake.hx
@@ -17,7 +17,7 @@ class HxMake extends hxmake.Module {
 		apply(HaxelibPlugin);
 
 		library(function(ext:HaxelibExt) {
-			ext.config.version = "0.2.2";
+			ext.config.version = "0.2.3";
 			ext.config.description = "Task automation for Haxe multi-module projects";
 			ext.config.url = "https://github.com/eliasku/hxmake";
 			ext.config.tags = ["haxe", "make", "build", "haxelib", "tools", "neko", "project", "module", "cross"];

--- a/src/hxmake/Task.hx
+++ b/src/hxmake/Task.hx
@@ -125,9 +125,9 @@ class Task {
 	}
 }
 
-
 private class EmptyTask extends Task {
-	function new() {}
+
+	public function new() {}
 
 	override public function run() {}
 }

--- a/src/hxmake/test/TestTask.hx
+++ b/src/hxmake/test/TestTask.hx
@@ -13,7 +13,7 @@ using hxmake.utils.HaxeTargetTools;
 
 class TestTask extends Task {
 
-	inline static var OPTION_OVERRIDE_TEST_TARGET:String = "--override-test-target=";
+	inline static var OPTION_OVERRIDE_TEST_TARGET:String = "--override-test-target";
 
 	public var debug:Bool = false;
 	public var targets:Array<String> = [];

--- a/src/hxmake/utils/GitTools.hx
+++ b/src/hxmake/utils/GitTools.hx
@@ -1,0 +1,26 @@
+package hxmake.utils;
+import hxmake.cli.CL;
+class GitTools {
+    /**
+        Return recent tag name with commit hash in format:
+        {tag name}-{commits count past recent tag}-{eight chars hash of last commit}
+
+        E.g.:
+            - If current position in tree referes to tag commit: 2.1.0
+            - If current position in tree referes to two commits past tag: 2.1.0-2-g2414721
+
+        @param dropSuffix   Drop last commit hash and commits count past tag
+    **/
+
+    public static function getCurrentTagVersion(dropSuffix:Bool = false):String {
+        var args = ["describe", "--tags"];
+        if (dropSuffix) {
+            args[args.length] = "--abbrev=0";
+        }
+        var result = CL.execute("git", args);
+        if (result.exitCode != 0) {
+            throw 'Can\'t get library version from git.\nExit code: ${result.exitCode}\n${result.stderr}';
+        }
+        return StringTools.trim(result.stdout);
+    }
+}


### PR DESCRIPTION
- Added hxmake.utils.GitTools#getCurrentTagVersion for retrieving current version from git tag
- Fix `--override-test-target` property for TestTask
- Update CI scripts
- Fix Haxe 4.0 compatibility